### PR TITLE
provide constructor option to skip JSON conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ of course):
 ```sh
 export VERA_ID=YOUR_VERACODE_ID
 export VERA_KEY=YOUR_VERACODE_SECRET
+export VERA_TEAM=SOME_TEAM_NAME_IN_YOUR_VERACODE_ACCOUNT // defaults to "Security"
 ```
 
 Now you'll be able to run the integration tests with `yarn test:integration`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ For convenience, all methods use objects to pass parameters, e.g. when the
 original function expects parameters `app_id` and `sandbox_id`, VeracodeClient
 function would be called the following object as parameter: `{appId, sandboxId}`
 
+By default, calls return JSON.  When creating the VeracodeClient you can set
+`returnXml` to `true` if you prefer to get back XML and convert it yourself.
+
 Please see tests for more examples.
 
 Usage example:
@@ -27,7 +30,8 @@ const VeracodeClient = require('@jupiterone/veracode-client');
 
 const veraClient = new VeracodeClient({
   apiId: process.env.VERA_ID,
-  apiKey: process.env.VERA_KEY
+  apiKey: process.env.VERA_KEY,
+  [returnXml: <boolean>]
 });
 
 const testAppInfo = {

--- a/src/VeracodeClient.js
+++ b/src/VeracodeClient.js
@@ -10,7 +10,7 @@ const archiver = require("archiver");
 
 /* Veracode HTTP request wrapper */
 class VeracodeClient {
-  constructor (apiId, apiKey) {
+  constructor (apiId, apiKey, returnXml = false) {
     // Errors returned on undefined API credentials are too confusing
     if (!(apiId && apiKey)) {
       throw new Error("Both Veracode API ID and key must be defined");
@@ -18,6 +18,7 @@ class VeracodeClient {
 
     this.apiId = apiId;
     this.apiKey = apiKey;
+    this.returnXml = returnXml;
 
     this.hashAlgorithm = "sha256";
     this.authScheme = "VERACODE-HMAC-SHA-256";
@@ -91,6 +92,10 @@ class VeracodeClient {
       formData: options.formData,
       gzip: true, // Veracode recommends to use GZIP whenever possible
     });
+
+    if (this.returnXml) {
+      return xmlResponse;
+    }
 
     const jsResponse = convert.xml2js(xmlResponse, { compact: true });
 

--- a/src/VeracodeClient.test.js
+++ b/src/VeracodeClient.test.js
@@ -106,14 +106,15 @@ describe("#_xmlRequest", () => {
     });
   });
 
-  test("returns xml", async () => {
+  test("can return xml", async () => {
     const xml = `
     <test account_id="123" app_id="456">
       <nested nested_id="789"/>
     </test>
     `;
     request.mockResolvedValue(xml);
-    const response = await veracodeClient._xmlRequest({ endpoint: "mytest.do", asXml: true });
+    const veracodeClient = new VeracodeClient(mockApiId, mockApiSecret, true);
+    const response = await veracodeClient._xmlRequest({ endpoint: "mytest.do" });
     const expectedUrl = new URL("mytest.do", veracodeClient.apiBase);
     expect(request).toBeCalledWith(baseRequestArg(expectedUrl, "GET"));
     expect(response).toEqual(xml);

--- a/src/VeracodeClient.test.js
+++ b/src/VeracodeClient.test.js
@@ -113,9 +113,9 @@ describe("#_xmlRequest", () => {
     </test>
     `;
     request.mockResolvedValue(xml);
-    const veracodeClient = new VeracodeClient(mockApiId, mockApiSecret, true);
-    const response = await veracodeClient._xmlRequest({ endpoint: "mytest.do" });
-    const expectedUrl = new URL("mytest.do", veracodeClient.apiBase);
+    const xmlVeracodeClient = new VeracodeClient(mockApiId, mockApiSecret, true);
+    const response = await xmlVeracodeClient._xmlRequest({ endpoint: "mytest.do" });
+    const expectedUrl = new URL("mytest.do", xmlVeracodeClient.apiBase);
     expect(request).toBeCalledWith(baseRequestArg(expectedUrl, "GET"));
     expect(response).toEqual(xml);
   });

--- a/src/VeracodeClient.test.js
+++ b/src/VeracodeClient.test.js
@@ -106,6 +106,19 @@ describe("#_xmlRequest", () => {
     });
   });
 
+  test("returns xml", async () => {
+    const xml = `
+    <test account_id="123" app_id="456">
+      <nested nested_id="789"/>
+    </test>
+    `;
+    request.mockResolvedValue(xml);
+    const response = await veracodeClient._xmlRequest({ endpoint: "mytest.do", asXml: true });
+    const expectedUrl = new URL("mytest.do", veracodeClient.apiBase);
+    expect(request).toBeCalledWith(baseRequestArg(expectedUrl, "GET"));
+    expect(response).toEqual(xml);
+  });
+
   test("throws error", async () => {
     request.mockResolvedValue("<error>Baby did a boom boom</error>");
     expect(veracodeClient._xmlRequest({ endpoint: "mytest.do" })).rejects.toThrow("Baby did a boom boom");

--- a/test/VeracodeClientIntegration.test.js
+++ b/test/VeracodeClientIntegration.test.js
@@ -17,7 +17,7 @@ const testApp = {
   appVersion: `test-version-${somethingUnique}`,
   sandboxName: `test-sandbox-${somethingUnique}`,
   businessCriticality: "High", // 'High' is used by security-scan, so using it here as well
-  teams: "Security", // Only security team will get notifications about this test app
+  teams: process.env.VERA_TEAM || "Security", // Only security team will get notifications about this test app
   autoScan: true, // Required to start scan automatically after pre-scan
   description: "This application is used to test veracode-client",
 };


### PR DESCRIPTION
by default, responses will be converted to JSON (from XML).  The
current converter doesn't handle collections uniformly.  If the collection
has 0 or 1 item, it becomes a JSON Object instead of an empty array or an
array of 1.

to be more backwards compatible, when you construct the `VeracodeClient`
you can simply provide a boolean flag that is used to bypass XML to JSON conversion.

by setting the default to `false`, current usages should remain unaffected

https://github.com/jasonrberk/veracode-client/tree/bypass-json-conversion