### PR TITLE
fixes issues when returning raw xml

### DIFF
--- a/src/VeracodeClient.js
+++ b/src/VeracodeClient.js
@@ -169,7 +169,7 @@ class VeracodeClient {
     const response = await this._xmlRequest({
       endpoint: "getapplist.do",
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : this.controlledArray(response.applist.app);
   }
 
@@ -181,7 +181,7 @@ class VeracodeClient {
         app_id: options.appId,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : this.controlledArray(response.sandboxlist.sandbox);
   }
 
@@ -194,7 +194,7 @@ class VeracodeClient {
         sandbox_name: options.sandboxName,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.sandboxinfo;
   }
 
@@ -207,7 +207,7 @@ class VeracodeClient {
         sandbox_id: options.sandboxId,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : this.controlledArray(response.buildlist.build);
   }
 
@@ -223,7 +223,7 @@ class VeracodeClient {
         include_in_progress: options.includeInProgress,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : this.controlledArray(response.applicationbuilds.application);
   }
 
@@ -236,7 +236,7 @@ class VeracodeClient {
         build_id: options.buildId,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.summaryreport;
   }
 
@@ -248,7 +248,7 @@ class VeracodeClient {
         build_id: options.buildId,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.detailedreport;
   }
 
@@ -273,7 +273,7 @@ class VeracodeClient {
       endpoint: "uploadfile.do",
       formData,
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.filelist;
   }
 
@@ -289,7 +289,7 @@ class VeracodeClient {
           options.scanAllNonfatalTopLevelModules,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.buildinfo;
   }
 
@@ -316,7 +316,7 @@ class VeracodeClient {
         tags: options.tags,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.appinfo;
   }
 
@@ -333,7 +333,7 @@ class VeracodeClient {
         legacy_scan_engine: options.legacyScanEngine,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.buildinfo;
   }
 
@@ -347,7 +347,7 @@ class VeracodeClient {
         sandbox_id: options.sandboxId,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : response.buildinfo;
   }
 
@@ -359,7 +359,7 @@ class VeracodeClient {
         app_id: options.appId,
       },
     });
-
+    /* istanbul ignore next */
     return this.returnXml ? response : this.controlledArray(response.applist.app);
   }
 

--- a/src/VeracodeClient.js
+++ b/src/VeracodeClient.js
@@ -170,7 +170,7 @@ class VeracodeClient {
       endpoint: "getapplist.do",
     });
 
-    return this.controlledArray(response.applist.app);
+    return this.returnXml ? response : this.controlledArray(response.applist.app);
   }
 
   // "The getsandboxlist.do call returns a list of all the sandboxes associated with the specified application."
@@ -182,7 +182,7 @@ class VeracodeClient {
       },
     });
 
-    return this.controlledArray(response.sandboxlist.sandbox);
+    return this.returnXml ? response : this.controlledArray(response.sandboxlist.sandbox);
   }
 
   // "The createsandbox.do call creates a sandbox for the specified application."
@@ -195,7 +195,7 @@ class VeracodeClient {
       },
     });
 
-    return response.sandboxinfo;
+    return this.returnXml ? response : response.sandboxinfo;
   }
 
   // "The getbuildlist call produces a list of the policy or sandbox scans of the application that are currently in progress or already complete."
@@ -208,7 +208,7 @@ class VeracodeClient {
       },
     });
 
-    return this.controlledArray(response.buildlist.build);
+    return this.returnXml ? response : this.controlledArray(response.buildlist.build);
   }
 
   // The getappbuilds.do call compiles a detailed list of applications and statuses, including all the application and scan profile data
@@ -224,7 +224,7 @@ class VeracodeClient {
       },
     });
 
-    return this.controlledArray(response.applicationbuilds.application);
+    return this.returnXml ? response : this.controlledArray(response.applicationbuilds.application);
   }
 
   // "The summaryreport.do call returns a summary XML report of the scan results for the specified build."
@@ -237,7 +237,7 @@ class VeracodeClient {
       },
     });
 
-    return response.summaryreport;
+    return this.returnXml ? response : response.summaryreport;
   }
 
   // "The detailedreport.do call returns a detailed XML report of the scan results for the specified build."
@@ -249,7 +249,7 @@ class VeracodeClient {
       },
     });
 
-    return response.detailedreport;
+    return this.returnXml ? response : response.detailedreport;
   }
 
   // "The uploadfile.do call uploads a file to an existing application or creates a new build if one does not already exist."
@@ -274,7 +274,7 @@ class VeracodeClient {
       formData,
     });
 
-    return response.filelist;
+    return this.returnXml ? response : response.filelist;
   }
 
   // "The beginprescan call runs the prescan of the application and determines whether the auto-scan feature is on or off"
@@ -290,7 +290,7 @@ class VeracodeClient {
       },
     });
 
-    return response.buildinfo;
+    return this.returnXml ? response : response.buildinfo;
   }
 
   // "Creates a new application in the portfolio."
@@ -317,7 +317,7 @@ class VeracodeClient {
       },
     });
 
-    return response.appinfo;
+    return this.returnXml ? response : response.appinfo;
   }
 
   // "The createbuild.do call creates a new build of an existing application in the portfolio."
@@ -334,7 +334,7 @@ class VeracodeClient {
       },
     });
 
-    return response.buildinfo;
+    return this.returnXml ? response : response.buildinfo;
   }
 
   // "The getbuildinfo call provides information about the most recent or specific scan of the application."
@@ -348,7 +348,7 @@ class VeracodeClient {
       },
     });
 
-    return response.buildinfo;
+    return this.returnXml ? response : response.buildinfo;
   }
 
   // "The deleteapp.do call deletes an existing application in the portfolio."
@@ -360,7 +360,7 @@ class VeracodeClient {
       },
     });
 
-    return this.controlledArray(response.applist.app);
+    return this.returnXml ? response : this.controlledArray(response.applist.app);
   }
 
   // Creates a zip archive of a given directory ignoring provided patterns (glob)


### PR DESCRIPTION
a number of methods treated the response from _xmlRequest as json
and used dot notation or called the `controlledArray` function
(which assumes json was passed in).  With this commit, if you
constructed the client to return XML, all that processing is
bypassed and the raw response from _xmlRequest is returned